### PR TITLE
Fix 0.12 compatibility issues

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "aws_lambda_function" "function" {
     mode = "${var.tracing_mode}"
   }
   environment {
-    variables {
+    variables = {
       TZ = "${var.timezone}"
 
       ES_HOST      = "${var.elasticsearch_host}"


### PR DESCRIPTION
fixes:
```
Error: Unsupported block type

  on .terraform/modules/es_cleaner/baikonur-oss-terraform-aws-lambda-es-cleaner-b06edf6/main.tf line 36, in resource "aws_lambda_function" "function":
  36:     variables {

Blocks of type "variables" are not expected here. Did you mean to define
argument "variables"? If so, use the equals sign to assign it a value.
```