### PR TITLE
0.12 upgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.7.3
+  rev: v1.16.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For more information on module version pinning, see [Selecting a Revision](https
 | name | Resource name | string | n/a | yes |
 | runtime | Lambda Function runtime | string | `"python3.7"` | no |
 | schedule\_expression | Lambda Schedule Expressions for Rules (https://docs.aws.amazon.com/ja_jp/AmazonCloudWatch/latest/events/ScheduledEvents.html) | string | n/a | yes |
-| tags | Tags for Lambda Function | map | `<map>` | no |
+| tags | Tags for Lambda Function | map(string) | `{}` | no |
 | timeout | Lambda Function timeout in seconds | string | `"60"` | no |
 | timezone | tz database timezone name (e.g. Asia/Tokyo) | string | `"UTC"` | no |
 | tracing\_mode | X-Ray tracing mode (see: https://docs.aws.amazon.com/lambda/latest/dg/API_TracingConfig.html ) | string | `"PassThrough"` | no |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Terraform module for automatically deleting Elasticsearch index exceeding maximum retention period.
 
-![terraform v0.11.x](https://img.shields.io/badge/terraform-v0.11.x-brightgreen.svg)
+![terraform v0.12.x](https://img.shields.io/badge/terraform-v0.12.x-brightgreen.svg)
 
 ## Prerequisites
 

--- a/main.tf
+++ b/main.tf
@@ -9,18 +9,18 @@ data "external" "package" {
 resource "aws_cloudwatch_log_group" "logs" {
   name = "/aws/lambda/${var.name}"
 
-  retention_in_days = "${var.log_retention_in_days}"
+  retention_in_days = var.log_retention_in_days
 }
 
 resource "aws_lambda_function" "function" {
-  function_name = "${var.name}"
-  handler       = "${var.handler}"
-  role          = "${module.iam.arn}"
-  runtime       = "${var.runtime}"
-  memory_size   = "${var.memory}"
-  timeout       = "${var.timeout}"
+  function_name = var.name
+  handler       = var.handler
+  role          = module.iam.arn
+  runtime       = var.runtime
+  memory_size   = var.memory
+  timeout       = var.timeout
 
-  filename = "${local.package_filename}"
+  filename = local.package_filename
 
   # Below is a very dirty hack to force base64sha256 to wait until 
   # package download in data.external.package finishes.
@@ -28,38 +28,39 @@ resource "aws_lambda_function" "function" {
   # WARNING: explicit depends_on from this resource to data.external.package 
   # does not help
 
-  source_code_hash = "${base64sha256(file("${jsonencode(data.external.package.result) == "{}" ? local.package_filename : ""}"))}"
+  source_code_hash = filebase64sha256(
+    jsonencode(data.external.package.result) == "{}" ? local.package_filename : "",
+  )
   tracing_config {
-    mode = "${var.tracing_mode}"
+    mode = var.tracing_mode
   }
   environment {
     variables = {
-      TZ = "${var.timezone}"
-
-      ES_HOST      = "${var.elasticsearch_host}"
-      MAX_AGE_DAYS = "${var.max_age_days}"
-      DRY_RUN_ONLY = "${var.dry_run_only}"
+      TZ           = var.timezone
+      ES_HOST      = var.elasticsearch_host
+      MAX_AGE_DAYS = var.max_age_days
+      DRY_RUN_ONLY = var.dry_run_only
     }
   }
-  tags = "${var.tags}"
+  tags = var.tags
 }
 
 resource "aws_cloudwatch_event_rule" "rule" {
-  name                = "${var.name}"
-  schedule_expression = "${var.schedule_expression}"
+  name                = var.name
+  schedule_expression = var.schedule_expression
 }
 
 resource "aws_cloudwatch_event_target" "target" {
-  arn  = "${aws_lambda_function.function.arn}"
-  rule = "${aws_cloudwatch_event_rule.rule.name}"
+  arn  = aws_lambda_function.function.arn
+  rule = aws_cloudwatch_event_rule.rule.name
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_invocation" {
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.function.function_name}"
+  function_name = aws_lambda_function.function.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = "${aws_cloudwatch_event_rule.rule.arn}"
+  source_arn    = aws_cloudwatch_event_rule.rule.arn
 }
 
 module "iam" {
@@ -67,7 +68,7 @@ module "iam" {
   version = "v1.0.1"
 
   type = "lambda"
-  name = "${var.name}"
+  name = var.name
 
   policy_json = <<EOF
 {
@@ -97,4 +98,6 @@ module "iam" {
     ]
 }
 EOF
+
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -60,7 +60,7 @@ variable "tracing_mode" {
 
 variable "tags" {
   description = "Tags for Lambda Function"
-  type        = "map"
+  type        = map(string)
   default     = {}
 }
 
@@ -68,3 +68,4 @@ variable "log_retention_in_days" {
   description = "Lambda Function log retention in days"
   default     = 30
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Terraform 0.12 breaks support for `file()` calls on non-plaintext binary files:
```
Error: Error in function call

  on .terraform/modules/es_cleaner/baikonur-oss-terraform-aws-lambda-es-cleaner-b0521a1/main.tf line 31, in resource "aws_lambda_function" "function":
  31:   source_code_hash = "${base64sha256(file("${jsonencode(data.external.package.result) == "{}" ? local.package_filename : ""}"))}"
    |----------------
    | data.external.package.result is empty map of string
    | local.package_filename is ".terraform/modules/es_cleaner/baikonur-oss-terraform-aws-lambda-es-cleaner-b0521a1/package.zip"

Call to function "file" failed: contents of
.terraform/modules/es_cleaner/baikonur-oss-terraform-aws-lambda-es-cleaner-b0521a1/package.zip
are not valid UTF-8; use the filebase64 function to obtain the Base64 encoded
contents or the other file functions (e.g. filemd5, filesha256) to obtain file
hashing results instead.
```

Since `filebase64sha256` is not available in 0.11, iIn order to support 0.12 in this module we have to drop 0.11 support altogether.