### PR TITLE
Update baikonur-oss/iam-nofile/aws to v2.0.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_invocation" {
 
 module "iam" {
   source  = "baikonur-oss/iam-nofile/aws"
-  version = "v1.0.1"
+  version = "v2.0.0"
 
   type = "lambda"
   name = var.name


### PR DESCRIPTION
iam-nofileが古いため、2.0.0に更新しました

```
There are some problems with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.
╷
│ Error: Invalid quoted type constraints
│ 
│   on .terraform/modules/es_cleaner.iam/variables.tf line 3, in variable "name":
│    3:   type        = "string"
│ 
│ Terraform 0.11 and earlier required type constraints to be given in quotes, but that form is now deprecated and will be removed in a future version of Terraform. Remove the quotes around "string".
╵

╷
│ Error: Invalid quoted type constraints
│ 
│   on .terraform/modules/es_cleaner.iam/variables.tf line 8, in variable "type":
│    8:   type        = "string"
│ 
│ Terraform 0.11 and earlier required type constraints to be given in quotes, but that form is now deprecated and will be removed in a future version of Terraform. Remove the quotes around "string".
╵

╷
│ Error: Invalid quoted type constraints
│ 
│   on .terraform/modules/es_cleaner.iam/variables.tf line 13, in variable "policy_json":
│   13:   type        = "string"
│ 
│ Terraform 0.11 and earlier required type constraints to be given in quotes, but that form is now deprecated and will be removed in a future version of Terraform. Remove the quotes around "string".
╵
```